### PR TITLE
gas can damage nerf

### DIFF
--- a/common/src/definitions/melees.ts
+++ b/common/src/definitions/melees.ts
@@ -134,7 +134,7 @@ export const Melees: MeleeDefinition[] = [
         idString: "gas_can",
         name: "Gas Can",
         itemType: ItemType.Melee,
-        damage: 22,
+        damage: 20,
         obstacleMultiplier: 1,
         radius: 1.75,
         offset: Vec.create(3.1, 0.5),


### PR DESCRIPTION
1. It is a puzzle item. Why does it do more damage than fists
2. Even if it is supposed to be better than just fists, why does it only do 10% more. If you wanted it to be better it should be noticeably better than fists